### PR TITLE
`2回東京10日` から `東京` を取得する正規表現の誤りを修正した

### DIFF
--- a/src/main/java/crawler/jra/util/ScrapingUtils.java
+++ b/src/main/java/crawler/jra/util/ScrapingUtils.java
@@ -20,7 +20,7 @@ public class ScrapingUtils {
 	private static Pattern doActionPtn = Pattern.compile("[a-z\\s]*doAction\\('.+',\\s*'(.+)'");
 
 	/** . */
-	private static Pattern kaisaiNmPtn = Pattern.compile("(\\d+)回(.+)(\\d+)日");
+	private static Pattern kaisaiNmPtn = Pattern.compile("(\\d+)回(\\D+)(\\d+)日");
 
 	/**
 	 * .


### PR DESCRIPTION
以下のサイトで動作確認可能
https://regex-testdrive.com/ja/dotest