### PR TITLE
リクエストタイムアウト: 60 秒を設定した

### DIFF
--- a/src/main/java/crawler/jra/constant/Const.java
+++ b/src/main/java/crawler/jra/constant/Const.java
@@ -19,6 +19,8 @@ public class Const {
 	/** JRA オッズページ URL */
 	public static final String ODDS_URL = BASE_URL + "/JRADB/accessO.html";
 
+	public static final int REQUEST_TIMEOUT_MS = 60_000;
+
 	/** 競馬場とコードの Map */
 	public static Map<String, String> keibajoNmCdMap;
 	static {

--- a/src/main/java/crawler/jra/page/TopPage.java
+++ b/src/main/java/crawler/jra/page/TopPage.java
@@ -26,7 +26,7 @@ public class TopPage {
 	 */
 	public TopPage() {
 		try {
-			this.document = Jsoup.connect(Const.BASE_URL).get();
+			this.document = Jsoup.connect(Const.BASE_URL).timeout(Const.REQUEST_TIMEOUT_MS).get();
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}


### PR DESCRIPTION
`java.lang.RuntimeException: java.net.SocketTimeoutException: Read timed out` が発生したため、
以下の記述に則り、リクエスト・タイムアウトを設定した
* https://jsoup.org/apidocs/org/jsoup/Connection.html#timeout-int-
> Set the total request timeout duration. If a timeout occurs, an SocketTimeoutException will be thrown.
The default timeout is 30 seconds (30,000 millis). A timeout of zero is treated as an infinite timeout.
Note that this timeout specifies the combined maximum duration of the connection time and the time to read the full response.